### PR TITLE
feat(npm): publish to AWS CodeArtifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ You can also execute individual publishers:
 
 ## npm
 
-Publishes all `*.tgz` files from `DIR` to [npmjs](npmjs.com) or [GitHub Packages](https://github.com/features/packages).
+Publishes all `*.tgz` files from `DIR` to [npmjs](npmjs.com), [GitHub Packages](https://github.com/features/packages) or [AWS CodeArtifact](https://aws.amazon.com/codeartifact/).
+
+If AWS CodeArtifact is used as npm registry, a temporary npm authorization token is created using AWS CLI. Therefore, it is necessary to provide the necessary [configuration settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html), e.g. by passing access key ID and secret access key to this script.
 
 **Usage:**
 
@@ -57,9 +59,11 @@ npx jsii-release-npm [DIR]
 
 |Option|Required|Description|
 |------|--------|-----------|
-|`NPM_TOKEN`|Required|Registry authentication token (either [npm.js publishing token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) or a [GitHub personal access token](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages#authenticating-to-github-packages))|
-|`NPM_REGISTRY`|Optional|The registry URL (defaults to "registry.npmjs.org"). Use "npm.pkg.github.com" to publish to GitHub Packages|
+|`NPM_TOKEN`|Optional|Registry authentication token (either [npm.js publishing token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) or a [GitHub personal access token](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages#authenticating-to-github-packages)), not used for AWS CodeArtifact|
+|`NPM_REGISTRY`|Optional|The registry URL (defaults to "registry.npmjs.org"). Use "npm.pkg.github.com" to publish to GitHub Packages. Use repository endpoint for AWS CodeAtifact, e.g. "my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/npm/my_repo/".|
 |`NPM_DIST_TAG`|Optional|Registers the published package with the given [dist-tag](https://docs.npmjs.com/cli/dist-tag) (e.g. `next`, default is `latest`)|
+|`AWS_ACCESS_KEY_ID`|Optional|If AWS CodeArtifact is used as registry, an AWS access key can be spedified.|
+|`AWS_SECRET_ACCESS_KEY`|Optional|Secret access key that belongs to the AWS access key.|
 
 ## Maven
 

--- a/bin/jsii-release-npm
+++ b/bin/jsii-release-npm
@@ -9,14 +9,23 @@ set -eu
 #
 # DIR: directory where npm tarballs are found (default is `dist/js`).
 #
-# NPM_TOKEN (required): registry authentication token (either from npmjs or a GitHub personal access token)
+# NPM_TOKEN (optional): registry authentication token (either from npmjs or a GitHub personal access token), not used for AWS CodeArtifact
 # NPM_REGISTRY (optional): the registry URL (defaults to "registry.npmjs.org")
+# AWS_ACCESS_KEY_ID (optional): If AWS CodeArtifact is used as registry, an AWS access key can be spedified.
+# AWS_SECRET_ACCESS_KEY (optional): Secret access key that belongs to the AWS access key.
 #
 ###
 
 dir="${1:-"dist/js"}"
 
-if [ -z "${NPM_TOKEN:-}" ]; then
+
+if ! [ -z "${NPM_REGISTRY:-}" ] && [[ $NPM_REGISTRY =~ .codeartifact.*.amazonaws.com ]]; then
+  codeartifact_account="$(echo $NPM_REGISTRY | cut -d. -f1 | rev | cut -d- -f1 | rev)"
+  codeartifact_subdomain="$(echo $NPM_REGISTRY | cut -d. -f1)"
+  codeartifact_domain="$(echo $codeartifact_subdomain | cut -b -$((${#codeartifact_subdomain}-${#codeartifact_account}-1)))"
+  codeartifact_region="$(echo $NPM_REGISTRY | cut -d. -f4)"
+  NPM_TOKEN=`aws codeartifact get-authorization-token --domain $codeartifact_domain --domain-owner $codeartifact_account --region $codeartifact_region --query authorizationToken --output text`
+elif [ -z "${NPM_TOKEN:-}" ]; then
   echo "NPM_TOKEN is required"
   exit 1
 fi


### PR DESCRIPTION
Publishing to npm packages to AWS CodeArtifact requires a `NPM_TOKEN` which is valid only for 12 hours. AWS CLI can be used to create this temporary `NPM_TOKEN`.

To automate publishing to AWS CodeArtifact, the `aws codeartifact login` command is added to the npm release script. It will be automatically executed when `NPM_REGISTRY` contains a AWS CodeArtifact URL.

It is necessary to provide the credentials for AWS CLI, e.g. by using the environment variable. Other AWS CLI credential types are supported. For example AWS CLI will automatically use Instance profile credentials if the script is executed on EC2.

The changes were tested manually by providing environment variables and CLI credentials file. The example npm package was successfully published to AWS CodeArtifact.

This feature was implemented as discussed with @eladb in https://github.com/projen/projen/issues/986.