### PR TITLE
fix: gpg keygen instructions are not accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ npx jsii-release-maven [DIR]
 
 Install [GnuPG](https://gnupg.org/).
 
-Generate your key (use RSA, 4096, passphrase):
+Generate your key:
 
 ```console
-$ gpg --gen-key
+$ gpg --full-generate-key
+# select RSA only, 4096, passphrase
 ```
 
 Your selected passphrase goes to `MAVEN_GPG_PRIVATE_KEY_PASSPHRASE`.

--- a/bin/jsii-release-maven
+++ b/bin/jsii-release-maven
@@ -25,7 +25,7 @@ set -eu # we don't want "pipefail" to implement idempotency
 #
 # HOW TO CREATE A GPG KEY?
 #
-#   gpg --gen-key (use RSA, 4096, passphrase)
+#   gpg --full-generate-key (use RSA, 4096, passphrase)
 #
 # Export and publish the public key:
 #   1. gpg -a --export > public.pem


### PR DESCRIPTION
The `--gen-key` command of gpg has changed and now, in order to select options, users should use `--full-generate-key`.

