### PR TITLE
fix: go releases failing on non-default branches

### DIFF
--- a/src/help/git.ts
+++ b/src/help/git.ts
@@ -87,9 +87,11 @@ export function push(ref: string) {
  * @param options options.
  */
 export function checkout(branch: string, options: { createIfMissing?: boolean } ) {
-  const flags = [];
-  if (options.createIfMissing) { flags.push('-B'); }
-  shell.run(`git checkout${` ${flags.join(' ')}`} ${branch}`);
+  if (options.createIfMissing) {
+    shell.run(`(git show-branch origin/${branch}) && (git checkout ${branch}) || (git checkout -b ${branch})`);
+  } else {
+    shell.run(`git checkout ${branch}`);
+  }
 }
 
 /**

--- a/src/help/git.ts
+++ b/src/help/git.ts
@@ -88,10 +88,17 @@ export function push(ref: string) {
  */
 export function checkout(branch: string, options: { createIfMissing?: boolean } ) {
   if (options.createIfMissing) {
-    shell.run(`(git show-branch origin/${branch}) && (git checkout ${branch}) || (git checkout -b ${branch})`);
-  } else {
-    shell.run(`git checkout ${branch}`);
+    try {
+      shell.run(`git show-branch origin/${branch}`);
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('fatal: bad sha1 reference')) {
+        console.log('Remote branch not found, creating new branch.');
+        shell.run(`git checkout -B ${branch}`);
+        return;
+      }
+    }
   }
+  shell.run(`git checkout ${branch}`);
 }
 
 /**


### PR DESCRIPTION
When trying to release to a non-default branch, Go releases fail because during checkout, jsii-release tries to run `git checkout -B <branch>` (so that it creates the branch if it doesn't exist). The problem is that if the branch does exist in the remote but it is not the default, git creates the branch at origin/HEAD instead of at origin/<branch>.

To fix this we check if the branch exists in the remote, and if so just run "git checkout" without -b (which will automatically track the correct branch).

Example failure run: https://github.com/cdk8s-team/cdk8s-plus/runs/3657009630?check_suite_focus=true#step:4:40