### PR TITLE
chore: fix projen config after breaking change to build tasks

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -2,28 +2,25 @@
   "tasks": {
     "build": {
       "name": "build",
-      "description": "Full release build (test+compile)",
+      "description": "Full release build",
       "steps": [
         {
-          "exec": "npx projen"
+          "spawn": "default"
         },
         {
-          "spawn": "test"
+          "spawn": "pre-compile"
         },
         {
           "spawn": "compile"
         },
         {
+          "spawn": "post-compile"
+        },
+        {
+          "spawn": "test"
+        },
+        {
           "spawn": "package"
-        },
-        {
-          "exec": "yarn pack"
-        },
-        {
-          "exec": "mkdir -p dist/js"
-        },
-        {
-          "exec": "mv ./jsii-release-v*.tgz dist/js"
         }
       ]
     },
@@ -86,6 +83,7 @@
     },
     "default": {
       "name": "default",
+      "description": "Synthesize project files",
       "steps": [
         {
           "exec": "node .projenrc.js"
@@ -103,7 +101,7 @@
     },
     "package": {
       "name": "package",
-      "description": "Create an npm tarball",
+      "description": "Creates the distribution package",
       "steps": [
         {
           "exec": "mkdir -p dist/js"
@@ -115,6 +113,25 @@
           "exec": "mv *.tgz dist/js/"
         }
       ]
+    },
+    "post-compile": {
+      "name": "post-compile",
+      "description": "Runs after successful compilation",
+      "steps": [
+        {
+          "exec": "yarn pack"
+        },
+        {
+          "exec": "mkdir -p dist/js"
+        },
+        {
+          "exec": "mv ./jsii-release-v*.tgz dist/js"
+        }
+      ]
+    },
+    "pre-compile": {
+      "name": "pre-compile",
+      "description": "Prepare the project for compilation"
     },
     "publish:github": {
       "name": "publish:github",
@@ -174,9 +191,6 @@
       "name": "test",
       "description": "Run tests",
       "steps": [
-        {
-          "exec": "rm -fr lib/"
-        },
         {
           "exec": "jest --passWithNoTests --all --updateSnapshot"
         },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -20,9 +20,9 @@ const project = new TypeScriptProject({
 });
 
 // create tarball and move to dist/js so release workflow can pick it up from there.
-project.buildTask.exec('yarn pack');
-project.buildTask.exec('mkdir -p dist/js');
-project.buildTask.exec('mv ./jsii-release-v*.tgz dist/js');
+project.projectBuild.postCompileTask.exec('yarn pack');
+project.projectBuild.postCompileTask.exec('mkdir -p dist/js');
+project.projectBuild.postCompileTask.exec('mv ./jsii-release-v*.tgz dist/js');
 
 // we can't use 9.x because it doesn't work with node 10.
 const fsExtraVersion = '^8.0.0';

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "default": "npx projen default",
     "eslint": "npx projen eslint",
     "package": "npx projen package",
+    "post-compile": "npx projen post-compile",
+    "pre-compile": "npx projen pre-compile",
     "publish:github": "npx projen publish:github",
     "publish:npm": "npx projen publish:npm",
     "release": "npx projen release",
@@ -50,7 +52,7 @@
     "jest-junit": "^12",
     "json-schema": "^0.3.0",
     "npm-check-updates": "^11",
-    "projen": "^0.32.9",
+    "projen": "^0.33.1",
     "standard-version": "^9",
     "ts-jest": "^27.0.7",
     "typescript": "^3.9.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4666,10 +4666,10 @@ progress@^2.0.0, progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.32.9:
-  version "0.32.9"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.32.9.tgz#c6f117f390f9ff93fcba441cf581a255b2c18f10"
-  integrity sha512-0abnwWdz9j4FCt2stuU43Xqc/4uaZ2nX9bP2jZb845L13TvGur3vWtO+0UIhITH0ZI8uxP7n4YjZh5ViB+2ycg==
+projen@^0.33.1:
+  version "0.33.1"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.33.1.tgz#c247d213b50d032ca4e1bb04f58b4fadc73186ba"
+  integrity sha512-q4qJ3YMMONhlPxJUCSo+n9Yl2/mVe9eS8zyCNFiFAnpRkKRmSyPkKGUsnfdSliCTTfE2wdfKQY0/aYsouoyoMA==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
A recent feature to projen (projen/projen#1201) changed
the way that build tasks work. This breaks the upgrade workflow for this (and
several other projects).